### PR TITLE
Add a middleware initialization event.

### DIFF
--- a/tests/TestCase/ServerTest.php
+++ b/tests/TestCase/ServerTest.php
@@ -119,4 +119,17 @@ class ServerTest extends TestCase
         $server = new Server($app);
         $server->emit($server->run(null, $response), $emitter);
     }
+
+    public function testBuildMiddlewareEvent()
+    {
+        $app = new MiddlewareApplication($this->config);
+        $server = new Server($app);
+        $called = false;
+        $server->eventManager()->on('Server.buildMiddleware', function ($event, $middleware) use (&$called) {
+            $called = true;
+            $this->assertInstanceOf('Spekkoek\MiddlewareStack', $middleware);
+        });
+        $server->run();
+        $this->assertTrue($called, 'Event not triggered.');
+    }
 }


### PR DESCRIPTION
Having this event will allow other plugins to attach middleware in a way that doesn't require explicit interaction from an application developer.
